### PR TITLE
chore: add uv exclude-newer to prevent supply chain attacks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ extend-select = ["I"]
 [tool.uv]
 managed = true
 python-preference = "only-managed"
+exclude-newer = "7 days"
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
## Summary
- Adds `exclude-newer = "7 days"` to `[tool.uv]` in pyproject.toml
- Prevents uv from installing package versions published within the last 7 days, giving the community time to detect and yank malicious releases

## Test plan
- [x] Verify `uv lock` / `uv sync` still works with the setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)